### PR TITLE
add user event

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/common/event/UserProgressLogEvent.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/event/UserProgressLogEvent.java
@@ -1,0 +1,24 @@
+package de.unistuttgart.iste.gits.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+/**
+ * This class represents a user progress log event.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+public class UserProgressLogEvent {
+
+    private UUID userId;
+    private UUID contentId;
+    private boolean success;
+    private double correctness;
+    private int hintsUsed;
+    private Integer timeToComplete;
+
+}


### PR DESCRIPTION
## Description of changes
Adds new event for user progress tracking.
Used in content service and will be used in skill level and reward service.
Currently differs from the style that @BlueWaves2 used to define events. @BlueWaves2 , in my oppinion the other event classes shoul also be called ...Event instead of ...DTO and moved to this package.
I don't want to do this in this PR because the other services have to be adapted for such a change.