### PR TITLE
RealmRoles/Global roles field to header

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/common/dapr/DaprTopic.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/dapr/DaprTopic.java
@@ -1,6 +1,6 @@
 package de.unistuttgart.iste.gits.common.dapr;
 
-public enum Topic {
+public enum DaprTopic {
     COURSE_CHANGED("course-changed"),
     CHAPTER_CHANGED("chapter-changed"),
 
@@ -13,7 +13,7 @@ public enum Topic {
 
     private final String topic;
 
-    Topic(final String topic) {
+    DaprTopic(final String topic) {
         this.topic = topic;
     }
 

--- a/src/main/java/de/unistuttgart/iste/gits/common/dapr/TopicPublisher.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/dapr/TopicPublisher.java
@@ -22,14 +22,14 @@ public class TopicPublisher {
     private final DaprClient client;
 
     /**
-     * Method used to publish dapr messages to a topic
+     * Method used to publish dapr messages to a daprTopic
      *
      * @param dto message
      */
-    protected void publishEvent(final Object dto, final Topic topic) {
-        client.publishEvent(PUBSUB_NAME, topic.getTopic(), dto)
-                .doOnSuccess(response -> log.debug("Published message to topic {}: {}", topic.getTopic(), response))
-                .doOnError(error -> log.error("Error while publishing message to topic {}: {}", topic.getTopic(), error.getMessage()))
+    protected void publishEvent(final Object dto, final DaprTopic daprTopic) {
+        client.publishEvent(PUBSUB_NAME, daprTopic.getTopic(), dto)
+                .doOnSuccess(response -> log.debug("Published message to daprTopic {}: {}", daprTopic.getTopic(), response))
+                .doOnError(error -> log.error("Error while publishing message to daprTopic {}: {}", daprTopic.getTopic(), error.getMessage()))
                 .subscribe();
     }
 
@@ -44,7 +44,7 @@ public class TopicPublisher {
                 .courseId(courseId)
                 .operation(operation)
                 .build();
-        publishEvent(dto, Topic.COURSE_CHANGED);
+        publishEvent(dto, DaprTopic.COURSE_CHANGED);
     }
 
     /**
@@ -58,7 +58,7 @@ public class TopicPublisher {
                 .chapterIds(chapterIds)
                 .operation(operation)
                 .build();
-        publishEvent(dto, Topic.CHAPTER_CHANGED);
+        publishEvent(dto, DaprTopic.CHAPTER_CHANGED);
     }
 
     /**
@@ -72,7 +72,7 @@ public class TopicPublisher {
                 .operation(operation)
                 .build();
 
-        publishEvent(dto, Topic.CONTENT_CHANGED);
+        publishEvent(dto, DaprTopic.CONTENT_CHANGED);
     }
 
     /**
@@ -81,7 +81,7 @@ public class TopicPublisher {
      * @param userProgressLogEvent of the worked on content
      */
     public void notifyUserWorkedOnContent(final UserProgressLogEvent userProgressLogEvent) {
-        publishEvent(userProgressLogEvent, Topic.CONTENT_PROGRESSED);
+        publishEvent(userProgressLogEvent, DaprTopic.CONTENT_PROGRESSED);
     }
 
     /**
@@ -89,7 +89,7 @@ public class TopicPublisher {
      * @param userProgressLogEvent of the processed content
      */
     public void notifyUserProgressProcessed(final UserProgressLogEvent userProgressLogEvent) {
-        publishEvent(userProgressLogEvent, Topic.USER_PROGRESS_UPDATED);
+        publishEvent(userProgressLogEvent, DaprTopic.USER_PROGRESS_UPDATED);
     }
 
 }

--- a/src/main/java/de/unistuttgart/iste/gits/common/user_handling/LoggedInUser.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/user_handling/LoggedInUser.java
@@ -1,6 +1,7 @@
 package de.unistuttgart.iste.gits.common.user_handling;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
  */
 @Data
 @Builder
+@AllArgsConstructor
 public class LoggedInUser {
     private final UUID id;
     private final String userName;

--- a/src/main/java/de/unistuttgart/iste/gits/common/user_handling/LoggedInUser.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/user_handling/LoggedInUser.java
@@ -19,17 +19,20 @@ public class LoggedInUser {
     private final String firstName;
     private final String lastName;
     private final List<CourseMembership> courseMemberships;
+    private final List<String> realmRoles;
 
     public LoggedInUser(@JsonProperty("id") final UUID id,
                         @JsonProperty("userName") final String userName,
                         @JsonProperty("firstName") final String firstName,
                         @JsonProperty("lastName") final String lastName,
-                        @JsonProperty("courseMemberships") final List<CourseMembership> courseMemberships) {
+                        @JsonProperty("courseMemberships") final List<CourseMembership> courseMemberships,
+                        @JsonProperty("realmRoles") final List<String> realmRoles) {
         this.id = id;
         this.userName = userName;
         this.firstName = firstName;
         this.lastName = lastName;
         this.courseMemberships = courseMemberships;
+        this.realmRoles = realmRoles;
     }
 
     @Data

--- a/src/main/java/de/unistuttgart/iste/gits/common/user_handling/LoggedInUser.java
+++ b/src/main/java/de/unistuttgart/iste/gits/common/user_handling/LoggedInUser.java
@@ -5,8 +5,11 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * This class represents user data for a logged-in user as provided by keycloak.
@@ -19,7 +22,7 @@ public class LoggedInUser {
     private final String firstName;
     private final String lastName;
     private final List<CourseMembership> courseMemberships;
-    private final List<String> realmRoles;
+    private final Set<RealmRole> realmRoles;
 
     public LoggedInUser(@JsonProperty("id") final UUID id,
                         @JsonProperty("userName") final String userName,
@@ -32,7 +35,7 @@ public class LoggedInUser {
         this.firstName = firstName;
         this.lastName = lastName;
         this.courseMemberships = courseMemberships;
-        this.realmRoles = realmRoles;
+        this.realmRoles = RealmRole.getRolesFromKeycloakRoleList(realmRoles);
     }
 
     @Data
@@ -95,5 +98,22 @@ public class LoggedInUser {
          * The ranking of the role in the course. The higher the ranking, the more permissions the role has.
          */
         private final int roleRanking;
+    }
+
+    public enum RealmRole {
+
+        COURSE_CREATOR("course-creator"),
+        SUPER_USER("super-user");
+
+        private final String keycloakRoleName;
+
+        RealmRole(final String keycloakRoleName) {
+            this.keycloakRoleName = keycloakRoleName;
+        }
+
+        public static Set<RealmRole> getRolesFromKeycloakRoleList(final List<String> keycloakRoleList) {
+
+            return Arrays.stream(RealmRole.values()).filter(role -> keycloakRoleList.contains(role.keycloakRoleName)).collect(Collectors.toSet());
+        }
     }
 }

--- a/src/test/java/de/unistuttgart/iste/gits/common/TestUserUtil.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/TestUserUtil.java
@@ -1,0 +1,30 @@
+package de.unistuttgart.iste.gits.common;
+
+import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class TestUserUtil {
+
+    public static LoggedInUser generateUser(final LoggedInUser.CourseMembership... courseMemberships){
+
+        return LoggedInUser.builder()
+                .userName("userWithMemberships")
+                .id(UUID.randomUUID())
+                .firstName("firstName")
+                .lastName("lastName")
+                .courseMemberships(List.of(courseMemberships))
+                .realmRoles(List.of("course-creator"))
+                .build();
+    }
+
+    public static LoggedInUser.CourseMembership.CourseMembershipBuilder courseMembershipBuilder() {
+        return LoggedInUser.CourseMembership.builder()
+                .published(true)
+                .courseId(UUID.randomUUID())
+                .startDate(OffsetDateTime.now().minusDays(1))
+                .endDate(OffsetDateTime.now().plusDays(1));
+    }
+}

--- a/src/test/java/de/unistuttgart/iste/gits/common/TestUserUtil.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/TestUserUtil.java
@@ -4,6 +4,7 @@ import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class TestUserUtil {
@@ -16,7 +17,7 @@ public class TestUserUtil {
                 .firstName("firstName")
                 .lastName("lastName")
                 .courseMemberships(List.of(courseMemberships))
-                .realmRoles(List.of("course-creator"))
+                .realmRoles(Set.of(LoggedInUser.RealmRole.COURSE_CREATOR))
                 .build();
     }
 

--- a/src/test/java/de/unistuttgart/iste/gits/common/TestUserUtil.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/TestUserUtil.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public class TestUserUtil {
 
-    public static LoggedInUser generateUser(final LoggedInUser.CourseMembership... courseMemberships){
+    public static LoggedInUser createUserWithMemberships(final LoggedInUser.CourseMembership... courseMemberships){
 
         return LoggedInUser.builder()
                 .userName("userWithMemberships")

--- a/src/test/java/de/unistuttgart/iste/gits/common/user_handling/RequestHeaderUserProcessorTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/user_handling/RequestHeaderUserProcessorTest.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +52,7 @@ class RequestHeaderUserProcessorTest {
                 .firstName("John")
                 .lastName("Doe")
                 .courseMemberships(List.of(courseMembership))
-                .realmRoles(new ArrayList<>())
+                .realmRoles(new HashSet<>())
                 .build();
 
 

--- a/src/test/java/de/unistuttgart/iste/gits/common/user_handling/RequestHeaderUserProcessorTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/user_handling/RequestHeaderUserProcessorTest.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpHeaders;
 
 import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -30,23 +31,29 @@ class RequestHeaderUserProcessorTest {
                             "startDate": "2020-01-01T00:00:00.000Z",
                             "endDate": "2021-01-01T00:00:00.000Z"
                         }
-                    ]
+                    ],
+                    "realmRoles": []
                 }
                 """;
 
-        final LoggedInUser user = new LoggedInUser(
-                java.util.UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
-                "MyUserName",
-                "John",
-                "Doe",
-                List.of(new LoggedInUser.CourseMembership(
-                        java.util.UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
-                        LoggedInUser.UserRoleInCourse.STUDENT,
-                        true,
-                        OffsetDateTime.parse("2020-01-01T00:00:00.000Z"),
-                        OffsetDateTime.parse("2021-01-01T00:00:00.000Z"))
-                )
-        );
+        final LoggedInUser.CourseMembership courseMembership = LoggedInUser.CourseMembership.builder()
+                .courseId(java.util.UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+                .published(true)
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .startDate(OffsetDateTime.parse("2020-01-01T00:00:00.000Z"))
+                .endDate(OffsetDateTime.parse("2021-01-01T00:00:00.000Z"))
+                .build();
+
+
+        final LoggedInUser user = LoggedInUser.builder()
+                .id(java.util.UUID.fromString("123e4567-e89b-12d3-a456-426614174000"))
+                .userName("MyUserName")
+                .firstName("John")
+                .lastName("Doe")
+                .courseMemberships(List.of(courseMembership))
+                .realmRoles(new ArrayList<>())
+                .build();
+
 
         final HttpHeaders headers = new HttpHeaders();
         headers.add("CurrentUser", json);

--- a/src/test/java/de/unistuttgart/iste/gits/common/user_handling/UserCourseAccessValidatorTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/user_handling/UserCourseAccessValidatorTest.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.iste.gits.common.user_handling;
 
+import de.unistuttgart.iste.gits.common.TestUserUtil;
 import de.unistuttgart.iste.gits.common.exception.NoAccessToCourseException;
 import org.junit.jupiter.api.Test;
 
@@ -13,21 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class UserCourseAccessValidatorTest {
     @Test
     void testValidateUserHasAccessToCourse() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.STUDENT,
-                                true,
-                                OffsetDateTime.now().minusDays(1),
-                                OffsetDateTime.now().plusDays(1)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
@@ -38,71 +30,52 @@ class UserCourseAccessValidatorTest {
 
     @Test
     void testValidateUserHasNoAccessToCourseNotMemberOf() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.STUDENT,
-                                true,
-                                OffsetDateTime.now().minusDays(1),
-                                OffsetDateTime.now().plusDays(1)
-                        )
-                )
-        );
+
+        UUID randomCourseID = UUID.randomUUID();
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
+
+
 
         assertThrows(NoAccessToCourseException.class, () -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
                 LoggedInUser.UserRoleInCourse.STUDENT,
-                UUID.randomUUID()
+                randomCourseID
         ));
     }
 
     @Test
     void testValidateUserHasNoAccessToCourseNotPublished() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.STUDENT,
-                                false,
-                                OffsetDateTime.now().minusDays(1),
-                                OffsetDateTime.now().plusDays(1)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .published(false)
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
+
+        UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
         assertThrows(NoAccessToCourseException.class, () -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
                 LoggedInUser.UserRoleInCourse.STUDENT,
-                user.getCourseMemberships().get(0).getCourseId()
+                userCourseID
         ));
     }
 
     @Test
     void testValidateTutorHasAccessToCourseNotPublished() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.TUTOR,
-                                false,
-                                OffsetDateTime.now().minusDays(1),
-                                OffsetDateTime.now().plusDays(1)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .published(false)
+                .role(LoggedInUser.UserRoleInCourse.TUTOR)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
@@ -113,71 +86,52 @@ class UserCourseAccessValidatorTest {
 
     @Test
     void testValidateUserHasNoAccessToCourseWrongRole() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.STUDENT,
-                                true,
-                                OffsetDateTime.now().minusDays(1),
-                                OffsetDateTime.now().plusDays(1)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
+
+        UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
         assertThrows(NoAccessToCourseException.class, () -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
                 LoggedInUser.UserRoleInCourse.TUTOR,
-                user.getCourseMemberships().get(0).getCourseId()
+                userCourseID
         ));
     }
 
     @Test
     void testValidateUserHasNoAccessToCourseNotStartedYet() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.STUDENT,
-                                true,
-                                OffsetDateTime.now().plusDays(1),
-                                OffsetDateTime.now().plusDays(2)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .endDate(OffsetDateTime.now().plusDays(2))
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
+
+        UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
         assertThrows(NoAccessToCourseException.class, () -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
                 LoggedInUser.UserRoleInCourse.STUDENT,
-                user.getCourseMemberships().get(0).getCourseId()
+                userCourseID
         ));
     }
 
     @Test
-    void testValidateTutorHasAccesToCourseNotStartedYet() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.TUTOR,
-                                true,
-                                OffsetDateTime.now().plusDays(1),
-                                OffsetDateTime.now().plusDays(2)
-                        )
-                )
-        );
+    void testValidateTutorHasAccessToCourseNotStartedYet() {
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .endDate(OffsetDateTime.now().plusDays(2))
+                .role(LoggedInUser.UserRoleInCourse.TUTOR)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
@@ -188,46 +142,34 @@ class UserCourseAccessValidatorTest {
 
     @Test
     void testValidateUserHasNoAccessToCourseEnded() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.STUDENT,
-                                true,
-                                OffsetDateTime.now().minusDays(2),
-                                OffsetDateTime.now().minusDays(1)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .startDate(OffsetDateTime.now().minusDays(2))
+                .endDate(OffsetDateTime.now().minusDays(1))
+                .role(LoggedInUser.UserRoleInCourse.STUDENT)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
+
+        UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
         assertThrows(NoAccessToCourseException.class, () -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
                 LoggedInUser.UserRoleInCourse.STUDENT,
-                user.getCourseMemberships().get(0).getCourseId()
+                userCourseID
         ));
     }
 
     @Test
     void testValidateTutorHasAccessToCourseEnded() {
-        LoggedInUser user = new LoggedInUser(
-                UUID.randomUUID(),
-                "TestUser",
-                "Test",
-                "User",
-                List.of(
-                        new LoggedInUser.CourseMembership(
-                                UUID.randomUUID(),
-                                LoggedInUser.UserRoleInCourse.TUTOR,
-                                true,
-                                OffsetDateTime.now().minusDays(2),
-                                OffsetDateTime.now().minusDays(1)
-                        )
-                )
-        );
+
+        LoggedInUser.CourseMembership membership = TestUserUtil.courseMembershipBuilder()
+                .startDate(OffsetDateTime.now().minusDays(2))
+                .endDate(OffsetDateTime.now().minusDays(1))
+                .role(LoggedInUser.UserRoleInCourse.TUTOR)
+                .build();
+
+        LoggedInUser user = TestUserUtil.generateUser(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,

--- a/src/test/java/de/unistuttgart/iste/gits/common/user_handling/UserCourseAccessValidatorTest.java
+++ b/src/test/java/de/unistuttgart/iste/gits/common/user_handling/UserCourseAccessValidatorTest.java
@@ -5,7 +5,6 @@ import de.unistuttgart.iste.gits.common.exception.NoAccessToCourseException;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -19,7 +18,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.STUDENT)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
@@ -37,7 +36,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.STUDENT)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
 
 
@@ -56,7 +55,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.STUDENT)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
@@ -75,7 +74,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.TUTOR)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
@@ -91,7 +90,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.STUDENT)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
@@ -111,7 +110,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.STUDENT)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
@@ -131,7 +130,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.TUTOR)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,
@@ -149,7 +148,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.STUDENT)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         UUID userCourseID = user.getCourseMemberships().get(0).getCourseId();
 
@@ -169,7 +168,7 @@ class UserCourseAccessValidatorTest {
                 .role(LoggedInUser.UserRoleInCourse.TUTOR)
                 .build();
 
-        LoggedInUser user = TestUserUtil.generateUser(membership);
+        LoggedInUser user = TestUserUtil.createUserWithMemberships(membership);
 
         assertDoesNotThrow(() -> UserCourseAccessValidator.validateUserHasAccessToCourse(
                 user,


### PR DESCRIPTION
## Description of changes

Adding
- new field in header for logged-in user for realmRoles (keycloak)
- renamed Topic to DaprTopic (for Rick) 
- fixed Tests to contain changes
- refactored Testcode
- added Utility Tetsclass to generated testobjects for Testcases

  
## How has this been tested?
Please describe the test strategy you followed.

- [X] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [ ] manual, exploratory test
    
## Checklist before requesting a review
- [X] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My code fulfills all acceptance criteria
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [X] I have made corresponding changes to the documentation
- [X] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [X] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
